### PR TITLE
Introduce `sm_pt_resupply` and `sm_pt_instant_resupply`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@
 !scripting/compile.sh
 # Our entrypoint
 !scripting/p4sstime.sp
+
+# Here lies our gamedata!
+!gamedata/
+!gamedata/*

--- a/gamedata/p4sstime.txt
+++ b/gamedata/p4sstime.txt
@@ -1,0 +1,22 @@
+"Games"
+{
+    "tf"
+    {
+        "Signatures"
+        {
+            "CTFPlayer::ForceRegenerateAndRespawn"
+            {
+                "library"   "server"
+                "linux"     "@_ZN9CTFPlayer25ForceRegenerateAndRespawnEv"
+                "windows"   "\x55\x8B\xEC\x51\x56\x57\x8B\xF9\xC6\x45\xFF\x01"
+            }
+
+            "PointInRespawnRoom"
+            {
+                "library"   "server"
+                "linux"     "@_Z18PointInRespawnRoomPK11CBaseEntityRK6Vectorb"
+                "windows"   "\x55\x8B\xEC\x53\x33\xDB\x56\x57\x39\x1D"
+            }
+        }
+    }
+}

--- a/scripting/p4sstime/convars.sp
+++ b/scripting/p4sstime/convars.sp
@@ -154,6 +154,44 @@ Action Command_PasstimeJackPickupSound(int client, int args)
 	return Plugin_Handled;
 }
 
+void Hook_OnAllowInstantResupplyChange(ConVar convar, const char[] oldValue, const char[] newValue)
+{
+	if (!bAllowInstantResupply.BoolValue)
+	   return;
+
+	if (tfPlayerForceRegenerateAndRespawn == null)
+	{
+		LogError("Cannot allow instant resupply due to missing CTFPlayer::ForceRegenerateAndRespawn function");
+		bAllowInstantResupply.BoolValue = false;
+		return;
+	}
+
+	if (pointInRespawnRoom == null)
+	{
+		LogError("Cannot allow instant resupply due to missing PointInRespawnRoom function");
+		bAllowInstantResupply.BoolValue = false;
+		return;
+	}
+}
+Action Command_PasstimeResupply(int client, int args)
+{
+    if (!bAllowInstantResupply.BoolValue)
+        return Plugin_Handled;
+
+    if (!IsPlayerAlive(client))
+        return Plugin_Handled;
+
+    float origin[3];
+    GetClientAbsOrigin(client, origin);
+
+    if (!PointInRespawnRoom(client, origin, false))
+        return Plugin_Handled;
+
+    ForceRegenerateAndRespawn(client);
+
+    return Plugin_Handled;
+}
+
 void RemoveShotty(int client)
 {
 	if (bEquipStockWeapons.BoolValue)


### PR DESCRIPTION
A "resupply" bind consists of loading an item preset (by doing `load_itempreset 0`), and having `tf_respawn_on_loadoutchanges` set to `1`. This, however, results in a delayed resupply and respawn.

The delay is due to the how `tf_respawn_on_loadoutchanges` is implemented: the client will fire a `k_EMsgGCRespawnPostLoadoutChange` message to the GC, which will reach the server after some indirection, which delays the result.

We slightly re-implement the logic from the game, allowing for near-instantaneous resupply and respawn, without worrying about loadout changes.