### PR TITLE
Heavily modify cfgs to include tf passtime defaults

### DIFF
--- a/cfg/pt_cup.cfg
+++ b/cfg/pt_cup.cfg
@@ -7,10 +7,72 @@ servercfgfile "pt_cup" // sets server cfg to this config so that it gets autoexe
 
 sv_pure "0" // allows for custom jack models and custom ball reticles
 
-mp_winlimit      "3"    // sets server winlimit
-mp_timelimit     "0"    // unsets server timelimit
-mp_windifference "0"    // unsets windifference
-mp_maxrounds     "0"    // unsets maxrounds
+// Values for consistency serverside.
+tf_passtime_ball_damping_scale           "0.01f"
+tf_passtime_ball_drag_coefficient        "0.01f"
+tf_passtime_ball_inertia_scale           "1.0f"
+tf_passtime_ball_mass                    "1.0f"
+tf_passtime_ball_model                   "models/passtime/ball/passtime_ball.mdl"
+tf_passtime_ball_reset_time              "15"       // How long the ball can be neutral before being automatically reset
+tf_passtime_ball_rotdamping_scale        "1.0f"     // Higher values will prevent the ball from rolling on the ground.
+tf_passtime_ball_seek_range              "128"      // How close players have to be for the ball to be drawn to them.
+tf_passtime_ball_seek_speed_factor       "3"        // How fast the ball will move toward nearby players as a ratio of that player's max speed.
+tf_passtime_ball_sphere_collision        "1"        // Boolean value. If nonzero, override mdl collision with a perfect sphere collider.
+tf_passtime_ball_sphere_radius           "7.2f"     
+tf_passtime_ball_takedamage              "1"        // Enables shooting the ball
+tf_passtime_ball_takedamage_force        "800.0f"   // Controls how much the ball responds to being shot
+tf_passtime_experiment_autopass          "0"        
+tf_passtime_experiment_instapass         "0"        
+tf_passtime_experiment_instapass_charge  "0"        
+tf_passtime_experiment_telepass          "0"        // None, TeleportToCatcher, SwapWithCatcher, TeleportToCatcherMaintainPossession,
+tf_passtime_flinch_boost                 "0"        // Intensity of flinch on taking damage while carrying the ball. 0 to use TF defaults.
+tf_passtime_mode_homing_lock_sec         "1.5f"     // Number of seconds the ball carrier will stay locked on to a teammate after line of sight is broken.
+tf_passtime_mode_homing_speed            "1000.0f"  // How fast the ball moves during a pass.
+tf_passtime_overtime_idle_sec            "5"        // How many seconds the ball can be idle in overtime before the round ends.
+tf_passtime_pack_hp_per_sec              "2.0f"     // How many HP per second pack members are healed.
+tf_passtime_pack_range                   "512"      // How close players must be to the ball carrier to be included in the pack.
+tf_passtime_pack_speed                   "1"        // When set to 1, all players near the ball carrier will move the same speed.
+tf_passtime_player_reticles_enemies      "1"        // Controls HUD reticles for enemies. 0 = never, 1 = when carrying ball, 2 = always.
+tf_passtime_player_reticles_friends      "2"        // Controls HUD reticles for teammates. 0 = never, 1 = when carrying ball, 2 = always.
+tf_passtime_powerball_airtimebonus       "0"        // Ball meter points added per second of time a pass is in the air.
+tf_passtime_powerball_decay_delay        "10"       // Number of seconds between ball reaching full charge and decay beginning.
+tf_passtime_powerball_decayamount        "1"        // How many points are removed are removed per decay. (must be integer)
+tf_passtime_powerball_decaysec           "4.5f"     // How many seconds per decay when the ball is held.
+tf_passtime_powerball_decaysec_neutral   "1.5f"     // How many seconds per decay when the ball is neutral.
+tf_passtime_powerball_maxairtimebonus    "100"      // Cap on extra points added by tf_passtime_powerball_airtimebonus.
+tf_passtime_powerball_passpoints         "0"        // How many ball meter points are awarded for a complete pass.
+tf_passtime_powerball_threshold          "80"       // How many ball meter points it takes to unlock bonus goals.
+tf_passtime_save_stats                   "0"        
+tf_passtime_score_crit_sec               "0"        // How long a scoring team's crits last.
+tf_passtime_speedboost_on_get_ball_time  "2.0f"     // How many seconds of speed boost players get when they get the ball.
+tf_passtime_steal_on_melee               "1"        // Enables melee stealing.
+tf_passtime_teammate_steal_time          "45"       // How many seconds a player can hold the ball before teammates can steal it.
+// tf_passtime_throwarc_demoman             "0.1f"
+tf_passtime_throwarc_engineer            "0.1f"    
+tf_passtime_throwarc_heavy               "0.175f"    
+tf_passtime_throwarc_medic               "0.0f"    
+tf_passtime_throwarc_pyro                "0.1f"    
+tf_passtime_throwarc_scout               "0.1f"    
+tf_passtime_throwarc_sniper              "0.0f"    
+tf_passtime_throwarc_soldier             "0.1f"    
+tf_passtime_throwarc_spy                 "0.0f"    
+// tf_passtime_throwspeed_demoman           "800.0f"  
+tf_passtime_throwspeed_engineer          "850.0f"  
+tf_passtime_throwspeed_heavy             "850.0f"  
+tf_passtime_throwspeed_medic             "900.0f"  
+tf_passtime_throwspeed_pyro              "750.0f"  
+tf_passtime_throwspeed_scout             "700.0f"  
+tf_passtime_throwspeed_sniper            "900.0f"  
+tf_passtime_throwspeed_soldier           "800.0f"  
+tf_passtime_throwspeed_spy               "900.0f"  
+tf_passtime_throwspeed_velocity_scale    "0.33"  // How much player velocity to add when tossing (0=none 1=100%)
+
+
+mp_winlimit                  "2"    // sets server winlimit
+mp_timelimit                 "0"    // unsets server timelimit
+mp_windifference             "0"    // unsets windifference
+mp_maxrounds                 "0"    // unsets maxrounds
+tf_passtime_scores_per_round "5"    // Number of scores it takes to win a round. Similar to tf_flag_caps_per_round.
 
 // temp plugin settings since rgl's isn't updated for v2.0.0+
 sm_pt_stock_blocklist 1

--- a/cfg/pt_cup.cfg
+++ b/cfg/pt_cup.cfg
@@ -7,84 +7,12 @@ servercfgfile "pt_cup" // sets server cfg to this config so that it gets autoexe
 
 sv_pure "0" // allows for custom jack models and custom ball reticles
 
-// Values for consistency serverside.
-tf_passtime_ball_damping_scale           "0.01f"
-tf_passtime_ball_drag_coefficient        "0.01f"
-tf_passtime_ball_inertia_scale           "1.0f"
-tf_passtime_ball_mass                    "1.0f"
-tf_passtime_ball_model                   "models/passtime/ball/passtime_ball.mdl"
-tf_passtime_ball_reset_time              "15"       // How long the ball can be neutral before being automatically reset
-tf_passtime_ball_rotdamping_scale        "1.0f"     // Higher values will prevent the ball from rolling on the ground.
-tf_passtime_ball_seek_range              "128"      // How close players have to be for the ball to be drawn to them.
-tf_passtime_ball_seek_speed_factor       "3"        // How fast the ball will move toward nearby players as a ratio of that player's max speed.
-tf_passtime_ball_sphere_collision        "1"        // Boolean value. If nonzero, override mdl collision with a perfect sphere collider.
-tf_passtime_ball_sphere_radius           "7.2f"     
-tf_passtime_ball_takedamage              "1"        // Enables shooting the ball
-tf_passtime_ball_takedamage_force        "800.0f"   // Controls how much the ball responds to being shot
-tf_passtime_experiment_autopass          "0"        
-tf_passtime_experiment_instapass         "0"        
-tf_passtime_experiment_instapass_charge  "0"        
-tf_passtime_experiment_telepass          "0"        // None, TeleportToCatcher, SwapWithCatcher, TeleportToCatcherMaintainPossession,
-tf_passtime_flinch_boost                 "0"        // Intensity of flinch on taking damage while carrying the ball. 0 to use TF defaults.
-tf_passtime_mode_homing_lock_sec         "1.5f"     // Number of seconds the ball carrier will stay locked on to a teammate after line of sight is broken.
-tf_passtime_mode_homing_speed            "1000.0f"  // How fast the ball moves during a pass.
-tf_passtime_overtime_idle_sec            "30"        // How many seconds the ball can be idle in overtime before the round ends.
-tf_passtime_pack_hp_per_sec              "2.0f"     // How many HP per second pack members are healed.
-tf_passtime_pack_range                   "512"      // How close players must be to the ball carrier to be included in the pack.
-tf_passtime_pack_speed                   "1"        // When set to 1, all players near the ball carrier will move the same speed.
-tf_passtime_player_reticles_enemies      "1"        // Controls HUD reticles for enemies. 0 = never, 1 = when carrying ball, 2 = always.
-tf_passtime_player_reticles_friends      "2"        // Controls HUD reticles for teammates. 0 = never, 1 = when carrying ball, 2 = always.
-tf_passtime_powerball_airtimebonus       "0"        // Ball meter points added per second of time a pass is in the air.
-tf_passtime_powerball_decay_delay        "10"       // Number of seconds between ball reaching full charge and decay beginning.
-tf_passtime_powerball_decayamount        "1"        // How many points are removed are removed per decay. (must be integer)
-tf_passtime_powerball_decaysec           "4.5f"     // How many seconds per decay when the ball is held.
-tf_passtime_powerball_decaysec_neutral   "1.5f"     // How many seconds per decay when the ball is neutral.
-tf_passtime_powerball_maxairtimebonus    "100"      // Cap on extra points added by tf_passtime_powerball_airtimebonus.
-tf_passtime_powerball_passpoints         "0"        // How many ball meter points are awarded for a complete pass.
-tf_passtime_powerball_threshold          "80"       // How many ball meter points it takes to unlock bonus goals.
-tf_passtime_save_stats                   "0"        
-tf_passtime_score_crit_sec               "0"        // How long a scoring team's crits last.
-tf_passtime_speedboost_on_get_ball_time  "2.0f"     // How many seconds of speed boost players get when they get the ball.
-tf_passtime_steal_on_melee               "1"        // Enables melee stealing.
-tf_passtime_teammate_steal_time          "45"       // How many seconds a player can hold the ball before teammates can steal it.
-// tf_passtime_throwarc_demoman             "0.1f"
-tf_passtime_throwarc_engineer            "0.1f"    
-tf_passtime_throwarc_heavy               "0.175f"    
-tf_passtime_throwarc_medic               "0.0f"    
-tf_passtime_throwarc_pyro                "0.1f"    
-tf_passtime_throwarc_scout               "0.1f"    
-tf_passtime_throwarc_sniper              "0.0f"    
-tf_passtime_throwarc_soldier             "0.1f"    
-tf_passtime_throwarc_spy                 "0.0f"    
-// tf_passtime_throwspeed_demoman           "800.0f"  
-tf_passtime_throwspeed_engineer          "850.0f"  
-tf_passtime_throwspeed_heavy             "850.0f"  
-tf_passtime_throwspeed_medic             "900.0f"  
-tf_passtime_throwspeed_pyro              "750.0f"  
-tf_passtime_throwspeed_scout             "700.0f"  
-tf_passtime_throwspeed_sniper            "900.0f"  
-tf_passtime_throwspeed_soldier           "800.0f"  
-tf_passtime_throwspeed_spy               "900.0f"  
-tf_passtime_throwspeed_velocity_scale    "0.33"  // How much player velocity to add when tossing (0=none 1=100%)
-
-
-mp_winlimit                  "2"    // sets server winlimit
+mp_winlimit                  "3"    // sets server winlimit
 mp_timelimit                 "0"    // unsets server timelimit
 mp_windifference             "0"    // unsets windifference
 mp_maxrounds                 "0"    // unsets maxrounds
-tf_passtime_scores_per_round "5"    // Number of scores it takes to win a round. Similar to tf_flag_caps_per_round.
 
-// temp plugin settings since rgl's isn't updated for v2.0.0+
-sm_pt_stock_blocklist 1
-sm_pt_block_instant_respawn 1
-sm_pt_disable_intercept_blur 1
-sm_pt_disable_jack_drop_item_collision 1
-sm_pt_print_events 1
 sm_pt_allow_instant_resupply 0      // disable instant resupply option of sm_pt_resupply; experimental feature
-
-tf_passtime_throwarc_demoman 0.1f       // set demo throw arc to soldier's value
-tf_passtime_throwspeed_demoman 800.0f   // set demo throw speed to soldier's value
-sm_pt_medic_can_splash 1 // enable medic arrows making the ball go neutral
 
 mp_tournament_whitelist "cfg/pt_pug_whitelist.txt" // our WL will usually be more updated than RGLs
 

--- a/cfg/pt_global_official.cfg
+++ b/cfg/pt_global_official.cfg
@@ -8,14 +8,12 @@ servercfgfile "pt_global_official" // sets server cfg to this config so that it 
 
 sv_pure "2" // removes custom jack models and custom ball reticles, as sv_pure 2 is considered cheating in ETF2L and RGL.
 
-
 mp_winlimit                  "3"    // sets server winlimit
 mp_timelimit                 "0"    // unsets server timelimit
 mp_windifference             "0"    // unsets windifference
 mp_maxrounds                 "0"    // unsets maxrounds
 
 sm_pt_allow_instant_resupply 0      // disable instant resupply option of sm_pt_resupply; experimental feature
-
 
 mp_tournament_whitelist "cfg/pt_pug_whitelist.txt" // our WL will usually be more updated than RGLs
 

--- a/cfg/pt_global_official.cfg
+++ b/cfg/pt_global_official.cfg
@@ -8,10 +8,72 @@ servercfgfile "pt_global_official" // sets server cfg to this config so that it 
 
 sv_pure "2" // removes custom jack models and custom ball reticles, as sv_pure 2 is considerd cheating in ETF2L and RGL.
 
-mp_winlimit      "3"    // sets server winlimit, set to 3 for officials.
-mp_timelimit     "0"    // unsets server timelimit
-mp_windifference "0"    // unsets windifference
-mp_maxrounds     "0"    // unsets maxrounds
+// Values for consistency serverside.
+tf_passtime_ball_damping_scale           "0.01f"
+tf_passtime_ball_drag_coefficient        "0.01f"
+tf_passtime_ball_inertia_scale           "1.0f"
+tf_passtime_ball_mass                    "1.0f"
+tf_passtime_ball_model                   "models/passtime/ball/passtime_ball.mdl"
+tf_passtime_ball_reset_time              "15"       // How long the ball can be neutral before being automatically reset
+tf_passtime_ball_rotdamping_scale        "1.0f"     // Higher values will prevent the ball from rolling on the ground.
+tf_passtime_ball_seek_range              "128"      // How close players have to be for the ball to be drawn to them.
+tf_passtime_ball_seek_speed_factor       "3"        // How fast the ball will move toward nearby players as a ratio of that player's max speed.
+tf_passtime_ball_sphere_collision        "1"        // Boolean value. If nonzero, override mdl collision with a perfect sphere collider.
+tf_passtime_ball_sphere_radius           "7.2f"     
+tf_passtime_ball_takedamage              "1"        // Enables shooting the ball
+tf_passtime_ball_takedamage_force        "800.0f"   // Controls how much the ball responds to being shot
+tf_passtime_experiment_autopass          "0"        
+tf_passtime_experiment_instapass         "0"        
+tf_passtime_experiment_instapass_charge  "0"        
+tf_passtime_experiment_telepass          "0"        // None, TeleportToCatcher, SwapWithCatcher, TeleportToCatcherMaintainPossession,
+tf_passtime_flinch_boost                 "0"        // Intensity of flinch on taking damage while carrying the ball. 0 to use TF defaults.
+tf_passtime_mode_homing_lock_sec         "1.5f"     // Number of seconds the ball carrier will stay locked on to a teammate after line of sight is broken.
+tf_passtime_mode_homing_speed            "1000.0f"  // How fast the ball moves during a pass.
+tf_passtime_overtime_idle_sec            "5"        // How many seconds the ball can be idle in overtime before the round ends.
+tf_passtime_pack_hp_per_sec              "2.0f"     // How many HP per second pack members are healed.
+tf_passtime_pack_range                   "512"      // How close players must be to the ball carrier to be included in the pack.
+tf_passtime_pack_speed                   "1"        // When set to 1, all players near the ball carrier will move the same speed.
+tf_passtime_player_reticles_enemies      "1"        // Controls HUD reticles for enemies. 0 = never, 1 = when carrying ball, 2 = always.
+tf_passtime_player_reticles_friends      "2"        // Controls HUD reticles for teammates. 0 = never, 1 = when carrying ball, 2 = always.
+tf_passtime_powerball_airtimebonus       "0"        // Ball meter points added per second of time a pass is in the air.
+tf_passtime_powerball_decay_delay        "10"       // Number of seconds between ball reaching full charge and decay beginning.
+tf_passtime_powerball_decayamount        "1"        // How many points are removed are removed per decay. (must be integer)
+tf_passtime_powerball_decaysec           "4.5f"     // How many seconds per decay when the ball is held.
+tf_passtime_powerball_decaysec_neutral   "1.5f"     // How many seconds per decay when the ball is neutral.
+tf_passtime_powerball_maxairtimebonus    "100"      // Cap on extra points added by tf_passtime_powerball_airtimebonus.
+tf_passtime_powerball_passpoints         "0"        // How many ball meter points are awarded for a complete pass.
+tf_passtime_powerball_threshold          "80"       // How many ball meter points it takes to unlock bonus goals.
+tf_passtime_save_stats                   "0"        
+tf_passtime_score_crit_sec               "0"        // How long a scoring team's crits last.
+tf_passtime_speedboost_on_get_ball_time  "2.0f"     // How many seconds of speed boost players get when they get the ball.
+tf_passtime_steal_on_melee               "1"        // Enables melee stealing.
+tf_passtime_teammate_steal_time          "45"       // How many seconds a player can hold the ball before teammates can steal it.
+// tf_passtime_throwarc_demoman             "0.1f"
+tf_passtime_throwarc_engineer            "0.1f"    
+tf_passtime_throwarc_heavy               "0.175f"    
+tf_passtime_throwarc_medic               "0.0f"    
+tf_passtime_throwarc_pyro                "0.1f"    
+tf_passtime_throwarc_scout               "0.1f"    
+tf_passtime_throwarc_sniper              "0.0f"    
+tf_passtime_throwarc_soldier             "0.1f"    
+tf_passtime_throwarc_spy                 "0.0f"    
+// tf_passtime_throwspeed_demoman           "800.0f"  
+tf_passtime_throwspeed_engineer          "850.0f"  
+tf_passtime_throwspeed_heavy             "850.0f"  
+tf_passtime_throwspeed_medic             "900.0f"  
+tf_passtime_throwspeed_pyro              "750.0f"  
+tf_passtime_throwspeed_scout             "700.0f"  
+tf_passtime_throwspeed_sniper            "900.0f"  
+tf_passtime_throwspeed_soldier           "800.0f"  
+tf_passtime_throwspeed_spy               "900.0f"  
+tf_passtime_throwspeed_velocity_scale    "0.33"  // How much player velocity to add when tossing (0=none 1=100%)
+
+
+mp_winlimit                  "3"    // sets server winlimit
+mp_timelimit                 "0"    // unsets server timelimit
+mp_windifference             "0"    // unsets windifference
+mp_maxrounds                 "0"    // unsets maxrounds
+tf_passtime_scores_per_round "5"    // Number of scores it takes to win a round. Similar to tf_flag_caps_per_round.
 
 // temp plugin settings since rgl's isn't updated for v2.0.0+
 sm_pt_stock_blocklist 1

--- a/cfg/pt_global_official.cfg
+++ b/cfg/pt_global_official.cfg
@@ -6,86 +6,15 @@ exec "rgl_pt_base"
 
 servercfgfile "pt_global_official" // sets server cfg to this config so that it gets autoexeced on level change
 
-sv_pure "2" // removes custom jack models and custom ball reticles, as sv_pure 2 is considerd cheating in ETF2L and RGL.
-
-// Values for consistency serverside.
-tf_passtime_ball_damping_scale           "0.01f"
-tf_passtime_ball_drag_coefficient        "0.01f"
-tf_passtime_ball_inertia_scale           "1.0f"
-tf_passtime_ball_mass                    "1.0f"
-tf_passtime_ball_model                   "models/passtime/ball/passtime_ball.mdl"
-tf_passtime_ball_reset_time              "15"       // How long the ball can be neutral before being automatically reset
-tf_passtime_ball_rotdamping_scale        "1.0f"     // Higher values will prevent the ball from rolling on the ground.
-tf_passtime_ball_seek_range              "128"      // How close players have to be for the ball to be drawn to them.
-tf_passtime_ball_seek_speed_factor       "3"        // How fast the ball will move toward nearby players as a ratio of that player's max speed.
-tf_passtime_ball_sphere_collision        "1"        // Boolean value. If nonzero, override mdl collision with a perfect sphere collider.
-tf_passtime_ball_sphere_radius           "7.2f"     
-tf_passtime_ball_takedamage              "1"        // Enables shooting the ball
-tf_passtime_ball_takedamage_force        "800.0f"   // Controls how much the ball responds to being shot
-tf_passtime_experiment_autopass          "0"        
-tf_passtime_experiment_instapass         "0"        
-tf_passtime_experiment_instapass_charge  "0"        
-tf_passtime_experiment_telepass          "0"        // None, TeleportToCatcher, SwapWithCatcher, TeleportToCatcherMaintainPossession,
-tf_passtime_flinch_boost                 "0"        // Intensity of flinch on taking damage while carrying the ball. 0 to use TF defaults.
-tf_passtime_mode_homing_lock_sec         "1.5f"     // Number of seconds the ball carrier will stay locked on to a teammate after line of sight is broken.
-tf_passtime_mode_homing_speed            "1000.0f"  // How fast the ball moves during a pass.
-tf_passtime_overtime_idle_sec            "30"        // How many seconds the ball can be idle in overtime before the round ends.
-tf_passtime_pack_hp_per_sec              "2.0f"     // How many HP per second pack members are healed.
-tf_passtime_pack_range                   "512"      // How close players must be to the ball carrier to be included in the pack.
-tf_passtime_pack_speed                   "1"        // When set to 1, all players near the ball carrier will move the same speed.
-tf_passtime_player_reticles_enemies      "1"        // Controls HUD reticles for enemies. 0 = never, 1 = when carrying ball, 2 = always.
-tf_passtime_player_reticles_friends      "2"        // Controls HUD reticles for teammates. 0 = never, 1 = when carrying ball, 2 = always.
-tf_passtime_powerball_airtimebonus       "0"        // Ball meter points added per second of time a pass is in the air.
-tf_passtime_powerball_decay_delay        "10"       // Number of seconds between ball reaching full charge and decay beginning.
-tf_passtime_powerball_decayamount        "1"        // How many points are removed are removed per decay. (must be integer)
-tf_passtime_powerball_decaysec           "4.5f"     // How many seconds per decay when the ball is held.
-tf_passtime_powerball_decaysec_neutral   "1.5f"     // How many seconds per decay when the ball is neutral.
-tf_passtime_powerball_maxairtimebonus    "100"      // Cap on extra points added by tf_passtime_powerball_airtimebonus.
-tf_passtime_powerball_passpoints         "0"        // How many ball meter points are awarded for a complete pass.
-tf_passtime_powerball_threshold          "80"       // How many ball meter points it takes to unlock bonus goals.
-tf_passtime_save_stats                   "0"        
-tf_passtime_score_crit_sec               "0"        // How long a scoring team's crits last.
-tf_passtime_speedboost_on_get_ball_time  "2.0f"     // How many seconds of speed boost players get when they get the ball.
-tf_passtime_steal_on_melee               "1"        // Enables melee stealing.
-tf_passtime_teammate_steal_time          "45"       // How many seconds a player can hold the ball before teammates can steal it.
-// tf_passtime_throwarc_demoman             "0.1f"
-tf_passtime_throwarc_engineer            "0.1f"    
-tf_passtime_throwarc_heavy               "0.175f"    
-tf_passtime_throwarc_medic               "0.0f"    
-tf_passtime_throwarc_pyro                "0.1f"    
-tf_passtime_throwarc_scout               "0.1f"    
-tf_passtime_throwarc_sniper              "0.0f"    
-tf_passtime_throwarc_soldier             "0.1f"    
-tf_passtime_throwarc_spy                 "0.0f"    
-// tf_passtime_throwspeed_demoman           "800.0f"  
-tf_passtime_throwspeed_engineer          "850.0f"  
-tf_passtime_throwspeed_heavy             "850.0f"  
-tf_passtime_throwspeed_medic             "900.0f"  
-tf_passtime_throwspeed_pyro              "750.0f"  
-tf_passtime_throwspeed_scout             "700.0f"  
-tf_passtime_throwspeed_sniper            "900.0f"  
-tf_passtime_throwspeed_soldier           "800.0f"  
-tf_passtime_throwspeed_spy               "900.0f"  
-tf_passtime_throwspeed_velocity_scale    "0.33"  // How much player velocity to add when tossing (0=none 1=100%)
+sv_pure "2" // removes custom jack models and custom ball reticles, as sv_pure 2 is considered cheating in ETF2L and RGL.
 
 
 mp_winlimit                  "3"    // sets server winlimit
 mp_timelimit                 "0"    // unsets server timelimit
 mp_windifference             "0"    // unsets windifference
 mp_maxrounds                 "0"    // unsets maxrounds
-tf_passtime_scores_per_round "5"    // Number of scores it takes to win a round. Similar to tf_flag_caps_per_round.
 
-// temp plugin settings since rgl's isn't updated for v2.0.0+
-sm_pt_stock_blocklist 1
-sm_pt_block_instant_respawn 1
-sm_pt_disable_intercept_blur 1
-sm_pt_disable_jack_drop_item_collision 1
-sm_pt_print_events 1
 sm_pt_allow_instant_resupply 0      // disable instant resupply option of sm_pt_resupply; experimental feature
-
-tf_passtime_throwarc_demoman 0.1f       // set demo throw arc to soldier's value
-tf_passtime_throwspeed_demoman 800.0f   // set demo throw speed to soldier's value
-sm_pt_medic_can_splash 1 // allows medic to arrow the ball to make it neutral
 
 
 mp_tournament_whitelist "cfg/pt_pug_whitelist.txt" // our WL will usually be more updated than RGLs

--- a/cfg/pt_global_pug.cfg
+++ b/cfg/pt_global_pug.cfg
@@ -7,78 +7,8 @@ servercfgfile "pt_global_pug" // sets server cfg to this config so that it gets 
 
 sv_pure "0" // allows for custom jack models and custom ball reticles
 
-// Values for consistency serverside.
-tf_passtime_ball_damping_scale           "0.01f"
-tf_passtime_ball_drag_coefficient        "0.01f"
-tf_passtime_ball_inertia_scale           "1.0f"
-tf_passtime_ball_mass                    "1.0f"
-tf_passtime_ball_model                   "models/passtime/ball/passtime_ball.mdl"
-tf_passtime_ball_reset_time              "15"       // How long the ball can be neutral before being automatically reset
-tf_passtime_ball_rotdamping_scale        "1.0f"     // Higher values will prevent the ball from rolling on the ground.
-tf_passtime_ball_seek_range              "128"      // How close players have to be for the ball to be drawn to them.
-tf_passtime_ball_seek_speed_factor       "3"        // How fast the ball will move toward nearby players as a ratio of that player's max speed.
-tf_passtime_ball_sphere_collision        "1"        // Boolean value. If nonzero, override mdl collision with a perfect sphere collider.
-tf_passtime_ball_sphere_radius           "7.2f"     
-tf_passtime_ball_takedamage              "1"        // Enables shooting the ball
-tf_passtime_ball_takedamage_force        "800.0f"   // Controls how much the ball responds to being shot
-tf_passtime_experiment_autopass          "0"        
-tf_passtime_experiment_instapass         "0"        
-tf_passtime_experiment_instapass_charge  "0"        
-tf_passtime_experiment_telepass          "0"        // None, TeleportToCatcher, SwapWithCatcher, TeleportToCatcherMaintainPossession,
-tf_passtime_flinch_boost                 "0"        // Intensity of flinch on taking damage while carrying the ball. 0 to use TF defaults.
-tf_passtime_mode_homing_lock_sec         "1.5f"     // Number of seconds the ball carrier will stay locked on to a teammate after line of sight is broken.
-tf_passtime_mode_homing_speed            "1000.0f"  // How fast the ball moves during a pass.
-tf_passtime_overtime_idle_sec            "30"        // How many seconds the ball can be idle in overtime before the round ends.
-tf_passtime_pack_hp_per_sec              "2.0f"     // How many HP per second pack members are healed.
-tf_passtime_pack_range                   "512"      // How close players must be to the ball carrier to be included in the pack.
-tf_passtime_pack_speed                   "1"        // When set to 1, all players near the ball carrier will move the same speed.
-tf_passtime_player_reticles_enemies      "1"        // Controls HUD reticles for enemies. 0 = never, 1 = when carrying ball, 2 = always.
-tf_passtime_player_reticles_friends      "2"        // Controls HUD reticles for teammates. 0 = never, 1 = when carrying ball, 2 = always.
-tf_passtime_powerball_airtimebonus       "0"        // Ball meter points added per second of time a pass is in the air.
-tf_passtime_powerball_passpoints         "0"        // How many ball meter points are awarded for a complete pass.
-tf_passtime_score_crit_sec               "0"        // How long a scoring team's crits last.
-tf_passtime_speedboost_on_get_ball_time  "2.0f"     // How many seconds of speed boost players get when they get the ball.
-tf_passtime_steal_on_melee               "1"        // Enables melee stealing.
-tf_passtime_teammate_steal_time          "45"       // How many seconds a player can hold the ball before teammates can steal it.
-// tf_passtime_throwarc_demoman             "0.1f"
-tf_passtime_throwarc_engineer            "0.1f"    
-tf_passtime_throwarc_heavy               "0.175f"    
-tf_passtime_throwarc_medic               "0.0f"    
-tf_passtime_throwarc_pyro                "0.1f"    
-tf_passtime_throwarc_scout               "0.1f"    
-tf_passtime_throwarc_sniper              "0.0f"    
-tf_passtime_throwarc_soldier             "0.1f"    
-tf_passtime_throwarc_spy                 "0.0f"    
-// tf_passtime_throwspeed_demoman           "800.0f"  
-tf_passtime_throwspeed_engineer          "850.0f"  
-tf_passtime_throwspeed_heavy             "850.0f"  
-tf_passtime_throwspeed_medic             "900.0f"  
-tf_passtime_throwspeed_pyro              "750.0f"  
-tf_passtime_throwspeed_scout             "700.0f"  
-tf_passtime_throwspeed_sniper            "900.0f"  
-tf_passtime_throwspeed_soldier           "800.0f"  
-tf_passtime_throwspeed_spy               "900.0f"  
-tf_passtime_throwspeed_velocity_scale    "0.33"  // How much player velocity to add when tossing (0=none 1=100%)
-
-
-mp_winlimit                  "2"    // sets server winlimit
-mp_timelimit                 "0"    // unsets server timelimit
-mp_windifference             "0"    // unsets windifference
-mp_maxrounds                 "0"    // unsets maxrounds
-tf_passtime_scores_per_round "5"    // Number of scores it takes to win a round. Similar to tf_flag_caps_per_round.
-
-// temp plugin settings since rgl's isn't updated for v2.0.0+
-sm_pt_stock_blocklist 1
-sm_pt_block_instant_respawn 1
-sm_pt_disable_intercept_blur 1
-sm_pt_disable_jack_drop_item_collision 1
-sm_pt_print_events 1
+// experimental plugin feature
 sm_pt_allow_instant_resupply 1      // enable instant resupply option of sm_pt_resupply; experimental feature
-
-tf_passtime_throwarc_demoman "0.1f"       // set demo throw arc to soldier's value
-tf_passtime_throwspeed_demoman "800.0f"   // set demo throw speed to soldier's value
-sm_pt_medic_can_splash 1 // allows medic to arrow the ball to make it neutral
-
 
 mp_tournament_whitelist "cfg/pt_pug_whitelist.txt" // our WL will usually be more updated than RGLs
 

--- a/cfg/pt_global_pug.cfg
+++ b/cfg/pt_global_pug.cfg
@@ -7,10 +7,72 @@ servercfgfile "pt_global_pug" // sets server cfg to this config so that it gets 
 
 sv_pure "0" // allows for custom jack models and custom ball reticles
 
-mp_winlimit      "2"    // sets server winlimit
-mp_timelimit     "0"    // unsets server timelimit
-mp_windifference "0"    // unsets windifference
-mp_maxrounds     "0"    // unsets maxrounds
+// Values for consistency serverside.
+tf_passtime_ball_damping_scale           "0.01f"
+tf_passtime_ball_drag_coefficient        "0.01f"
+tf_passtime_ball_inertia_scale           "1.0f"
+tf_passtime_ball_mass                    "1.0f"
+tf_passtime_ball_model                   "models/passtime/ball/passtime_ball.mdl"
+tf_passtime_ball_reset_time              "15"       // How long the ball can be neutral before being automatically reset
+tf_passtime_ball_rotdamping_scale        "1.0f"     // Higher values will prevent the ball from rolling on the ground.
+tf_passtime_ball_seek_range              "128"      // How close players have to be for the ball to be drawn to them.
+tf_passtime_ball_seek_speed_factor       "3"        // How fast the ball will move toward nearby players as a ratio of that player's max speed.
+tf_passtime_ball_sphere_collision        "1"        // Boolean value. If nonzero, override mdl collision with a perfect sphere collider.
+tf_passtime_ball_sphere_radius           "7.2f"     
+tf_passtime_ball_takedamage              "1"        // Enables shooting the ball
+tf_passtime_ball_takedamage_force        "800.0f"   // Controls how much the ball responds to being shot
+tf_passtime_experiment_autopass          "0"        
+tf_passtime_experiment_instapass         "0"        
+tf_passtime_experiment_instapass_charge  "0"        
+tf_passtime_experiment_telepass          "0"        // None, TeleportToCatcher, SwapWithCatcher, TeleportToCatcherMaintainPossession,
+tf_passtime_flinch_boost                 "0"        // Intensity of flinch on taking damage while carrying the ball. 0 to use TF defaults.
+tf_passtime_mode_homing_lock_sec         "1.5f"     // Number of seconds the ball carrier will stay locked on to a teammate after line of sight is broken.
+tf_passtime_mode_homing_speed            "1000.0f"  // How fast the ball moves during a pass.
+tf_passtime_overtime_idle_sec            "5"        // How many seconds the ball can be idle in overtime before the round ends.
+tf_passtime_pack_hp_per_sec              "2.0f"     // How many HP per second pack members are healed.
+tf_passtime_pack_range                   "512"      // How close players must be to the ball carrier to be included in the pack.
+tf_passtime_pack_speed                   "1"        // When set to 1, all players near the ball carrier will move the same speed.
+tf_passtime_player_reticles_enemies      "1"        // Controls HUD reticles for enemies. 0 = never, 1 = when carrying ball, 2 = always.
+tf_passtime_player_reticles_friends      "2"        // Controls HUD reticles for teammates. 0 = never, 1 = when carrying ball, 2 = always.
+tf_passtime_powerball_airtimebonus       "0"        // Ball meter points added per second of time a pass is in the air.
+tf_passtime_powerball_decay_delay        "10"       // Number of seconds between ball reaching full charge and decay beginning.
+tf_passtime_powerball_decayamount        "1"        // How many points are removed are removed per decay. (must be integer)
+tf_passtime_powerball_decaysec           "4.5f"     // How many seconds per decay when the ball is held.
+tf_passtime_powerball_decaysec_neutral   "1.5f"     // How many seconds per decay when the ball is neutral.
+tf_passtime_powerball_maxairtimebonus    "100"      // Cap on extra points added by tf_passtime_powerball_airtimebonus.
+tf_passtime_powerball_passpoints         "0"        // How many ball meter points are awarded for a complete pass.
+tf_passtime_powerball_threshold          "80"       // How many ball meter points it takes to unlock bonus goals.
+tf_passtime_save_stats                   "0"        
+tf_passtime_score_crit_sec               "0"        // How long a scoring team's crits last.
+tf_passtime_speedboost_on_get_ball_time  "2.0f"     // How many seconds of speed boost players get when they get the ball.
+tf_passtime_steal_on_melee               "1"        // Enables melee stealing.
+tf_passtime_teammate_steal_time          "45"       // How many seconds a player can hold the ball before teammates can steal it.
+// tf_passtime_throwarc_demoman             "0.1f"
+tf_passtime_throwarc_engineer            "0.1f"    
+tf_passtime_throwarc_heavy               "0.175f"    
+tf_passtime_throwarc_medic               "0.0f"    
+tf_passtime_throwarc_pyro                "0.1f"    
+tf_passtime_throwarc_scout               "0.1f"    
+tf_passtime_throwarc_sniper              "0.0f"    
+tf_passtime_throwarc_soldier             "0.1f"    
+tf_passtime_throwarc_spy                 "0.0f"    
+// tf_passtime_throwspeed_demoman           "800.0f"  
+tf_passtime_throwspeed_engineer          "850.0f"  
+tf_passtime_throwspeed_heavy             "850.0f"  
+tf_passtime_throwspeed_medic             "900.0f"  
+tf_passtime_throwspeed_pyro              "750.0f"  
+tf_passtime_throwspeed_scout             "700.0f"  
+tf_passtime_throwspeed_sniper            "900.0f"  
+tf_passtime_throwspeed_soldier           "800.0f"  
+tf_passtime_throwspeed_spy               "900.0f"  
+tf_passtime_throwspeed_velocity_scale    "0.33"  // How much player velocity to add when tossing (0=none 1=100%)
+
+
+mp_winlimit                  "2"    // sets server winlimit
+mp_timelimit                 "0"    // unsets server timelimit
+mp_windifference             "0"    // unsets windifference
+mp_maxrounds                 "0"    // unsets maxrounds
+tf_passtime_scores_per_round "5"    // Number of scores it takes to win a round. Similar to tf_flag_caps_per_round.
 
 // temp plugin settings since rgl's isn't updated for v2.0.0+
 sm_pt_stock_blocklist 1

--- a/cfg/pt_global_pug.cfg
+++ b/cfg/pt_global_pug.cfg
@@ -35,14 +35,7 @@ tf_passtime_pack_speed                   "1"        // When set to 1, all player
 tf_passtime_player_reticles_enemies      "1"        // Controls HUD reticles for enemies. 0 = never, 1 = when carrying ball, 2 = always.
 tf_passtime_player_reticles_friends      "2"        // Controls HUD reticles for teammates. 0 = never, 1 = when carrying ball, 2 = always.
 tf_passtime_powerball_airtimebonus       "0"        // Ball meter points added per second of time a pass is in the air.
-tf_passtime_powerball_decay_delay        "10"       // Number of seconds between ball reaching full charge and decay beginning.
-tf_passtime_powerball_decayamount        "1"        // How many points are removed are removed per decay. (must be integer)
-tf_passtime_powerball_decaysec           "4.5f"     // How many seconds per decay when the ball is held.
-tf_passtime_powerball_decaysec_neutral   "1.5f"     // How many seconds per decay when the ball is neutral.
-tf_passtime_powerball_maxairtimebonus    "100"      // Cap on extra points added by tf_passtime_powerball_airtimebonus.
 tf_passtime_powerball_passpoints         "0"        // How many ball meter points are awarded for a complete pass.
-tf_passtime_powerball_threshold          "80"       // How many ball meter points it takes to unlock bonus goals.
-tf_passtime_save_stats                   "0"        
 tf_passtime_score_crit_sec               "0"        // How long a scoring team's crits last.
 tf_passtime_speedboost_on_get_ball_time  "2.0f"     // How many seconds of speed boost players get when they get the ball.
 tf_passtime_steal_on_melee               "1"        // Enables melee stealing.
@@ -82,8 +75,8 @@ sm_pt_disable_jack_drop_item_collision 1
 sm_pt_print_events 1
 sm_pt_allow_instant_resupply 1      // enable instant resupply option of sm_pt_resupply; experimental feature
 
-tf_passtime_throwarc_demoman 0.1f       // set demo throw arc to soldier's value
-tf_passtime_throwspeed_demoman 800.0f   // set demo throw speed to soldier's value
+tf_passtime_throwarc_demoman "0.1f"       // set demo throw arc to soldier's value
+tf_passtime_throwspeed_demoman "800.0f"   // set demo throw speed to soldier's value
 sm_pt_medic_can_splash 1 // allows medic to arrow the ball to make it neutral
 
 

--- a/cfg/pt_global_pug.cfg
+++ b/cfg/pt_global_pug.cfg
@@ -12,7 +12,6 @@ mp_timelimit                 "0"    // unsets server timelimit
 mp_windifference             "0"    // unsets windifference
 mp_maxrounds                 "0"    // unsets maxrounds
 
-// experimental plugin feature
 sm_pt_allow_instant_resupply 1      // enable instant resupply option of sm_pt_resupply; experimental feature
 
 mp_tournament_whitelist "cfg/pt_pug_whitelist.txt" // our WL will usually be more updated than RGLs

--- a/cfg/pt_global_pug.cfg
+++ b/cfg/pt_global_pug.cfg
@@ -7,6 +7,11 @@ servercfgfile "pt_global_pug" // sets server cfg to this config so that it gets 
 
 sv_pure "0" // allows for custom jack models and custom ball reticles
 
+mp_winlimit                  "2"    // sets server winlimit
+mp_timelimit                 "0"    // unsets server timelimit
+mp_windifference             "0"    // unsets windifference
+mp_maxrounds                 "0"    // unsets maxrounds
+
 // experimental plugin feature
 sm_pt_allow_instant_resupply 1      // enable instant resupply option of sm_pt_resupply; experimental feature
 


### PR DESCRIPTION
The cfgs previously did not include tf2's default Passtime cvar values. In theory someone could change all of these values and still be running a compliant version of the cfg