### PR TITLE
Introduce `sm_pt_instant_resupply_time_between` to limit resupply spam

### DIFF
--- a/scripting/p4sstime.sp
+++ b/scripting/p4sstime.sp
@@ -82,6 +82,7 @@ ConVar							bPracticeMode;
 ConVar							bVerboseLogs;
 ConVar							bMedicArrowsNeutralizeBall;
 ConVar							bAllowInstantResupply;
+ConVar							flInstantResupplyTimeBetween;
 
 int									iPlyWhoGotJack;
 // int			plyDirecter;
@@ -107,6 +108,7 @@ bool								arrbBlastJumpStatus[MAXPLAYERS + 1];	// true if blast jumping, false
 bool								arrbPanaceaCheck[MAXPLAYERS + 1];
 bool								arrbWinStratCheck[MAXPLAYERS + 1];
 bool								arrbDeathbombCheck[MAXPLAYERS + 1];
+float								nextInstantResupplyTime[MAXPLAYERS + 1];
 // bool			plyTakenDirectHit[MAXPLAYERS + 1];
 Cookie							cookieCountdownCaption, cookieJACKPickupHud, cookieJACKPickupChat, cookieJACKPickupSound, cookieSimpleChatPrint, cookieToggleChatPrint;
 
@@ -191,6 +193,7 @@ public void OnPluginStart()
 	bVerboseLogs							 = CreateConVar("sm_pt_logs_verbose", "0", "If 1, prints additional information to logs.");
 	bMedicArrowsNeutralizeBall = CreateConVar("sm_pt_medic_can_splash", "1", "If 1, allows medic crossbow arrows to neutralize the ball.", FCVAR_NOTIFY);
 	bAllowInstantResupply			 = CreateConVar("sm_pt_allow_instant_resupply", "0", "If 1, allows sm_pt_resupply.", FCVAR_NOTIFY);
+	flInstantResupplyTimeBetween = CreateConVar("sm_pt_instant_resupply_time_between", "0.5", "The number of seconds between each successful sm_pt_resupply.", FCVAR_NOTIFY);
 	// trikzEnable	 = CreateConVar("sm_pt_trikz", "0", "Set 'trikz' mode. 1 adds friendly knockback for airshots, 2 adds friendly knockback for splash damage, 3 adds friendly knockback for everywhere", FCVAR_NOTIFY, true, 0.0, true, 3.0);
 	// trikzProjCollide = CreateConVar("sm_pt_trikz_projcollide", "2", "Manually set team projectile collision behavior when trikz is on. 2 always collides, 1 will cause your projectiles to phase through if you are too close (default game behavior), 0 will cause them to never collide.", 0, true, 0.0, true, 2.0);
 	// trikzProjDev = CreateConVar("sm_pt_trikz_projcollide_dev", "0", "DONOTUSE; This command is used solely by the plugin to change values. Changing this manually may cause issues.", FCVAR_HIDDEN, true, 0.0, true, 2.0);

--- a/scripting/p4sstime/convars.sp
+++ b/scripting/p4sstime/convars.sp
@@ -157,7 +157,7 @@ Action Command_PasstimeJackPickupSound(int client, int args)
 void Hook_OnAllowInstantResupplyChange(ConVar convar, const char[] oldValue, const char[] newValue)
 {
 	if (!bAllowInstantResupply.BoolValue)
-	   return;
+	    return;
 
 	if (tfPlayerForceRegenerateAndRespawn == null)
 	{

--- a/scripting/p4sstime/convars.sp
+++ b/scripting/p4sstime/convars.sp
@@ -178,6 +178,9 @@ Action Command_PasstimeResupply(int client, int args)
     if (!bAllowInstantResupply.BoolValue)
         return Plugin_Handled;
 
+    if (nextInstantResupplyTime[client] > GetGameTime())
+        return Plugin_Handled;
+
     if (!IsPlayerAlive(client))
         return Plugin_Handled;
 
@@ -187,6 +190,7 @@ Action Command_PasstimeResupply(int client, int args)
     if (!PointInRespawnRoom(client, origin, false))
         return Plugin_Handled;
 
+    nextInstantResupplyTime[client] = GetGameTime() + flInstantResupplyTimeBetween.FloatValue;
     ForceRegenerateAndRespawn(client);
 
     return Plugin_Handled;


### PR DESCRIPTION
To prevent players from spamming their instant resupply binds needlessly, we introduce a configurable time that must pass between each successful resupply. This is by default `0.5` seconds.